### PR TITLE
Stream-based patching

### DIFF
--- a/Installer/Patching/PatchInfo.cs
+++ b/Installer/Patching/PatchInfo.cs
@@ -68,6 +68,20 @@ namespace TaleOfTwoWastelands.Patching
             }
         }
 
+        public bool PatchStream(Stream input, FileValidation targetChk, Stream output, out FileValidation outputChk)
+        {
+            unsafe
+            {
+                fixed (byte* pPatch = Data)
+                    Diff.Apply(input, pPatch, Data.LongLength, output);
+            }
+
+            output.Seek(0, SeekOrigin.Begin);
+            outputChk = new FileValidation(output, targetChk.Type);
+
+            return targetChk == outputChk;
+        }
+
 #if LEGACY || DEBUG
         public static PatchInfo FromOldDiff(byte[] diffData, FileValidation oldChk)
         {

--- a/Installer/Tale Of Two Wastelands Installer.csproj
+++ b/Installer/Tale Of Two Wastelands Installer.csproj
@@ -34,7 +34,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;PARALLEL</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
Addresses #12 by changing master patching to use streams for input and output instead of in-memory buffers. Diff.Apply is also heavily modified to reduce duplication and clean up the Diff API.
